### PR TITLE
Create GitHub Action Workflow to Unit Test API

### DIFF
--- a/.github/workflows/apiUnitTests.yml
+++ b/.github/workflows/apiUnitTests.yml
@@ -1,0 +1,31 @@
+name: API Unit Tests
+
+on:
+  push:
+    paths:
+      - '**/api/**'
+      - '.github/workflows/api**'
+  pull_request:
+    paths:
+      - '**/api/**'
+      - '.github/workflows/api**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test Node.js API
+      uses: actions/setup-node@v1
+      with:
+        node-version: 8
+    - name: Install Dependencies
+      working-directory: ./api
+      run: npm ci
+    - name: Run Tests
+      env:
+        accessKeyId: ${{ secrets.AWS_accessKeyId }}
+        secretAccessKey: ${{ secrets.AWS_secretAccessKey }}
+        region: ${{ secrets.AWS_region }}
+      working-directory: ./api
+      run: npm test

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "description": "API (backend) for recipe app",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --exit"
   },
   "author": "Chris Bombino",
   "license": "ISC",


### PR DESCRIPTION
I have made the decision to use GitHub Actions as my choice for CI/CD.
I didn't want to use a large system like Jenkins of TeamCity, so my
options were narrowed down to either CircleCI or GitHub Actions. I went
with GitHub Actions because I already use GitHub and using this for
CI/CD means one less application I need to look after. I did some
research and found that CircleCI and GitHub Actions offer many of the
same services for simple applications like this.

Getting started with GitHub Actions required creating a YAML file in a
new .github/workflows directory (I added the API subdirectory to break
up any future tests I'll create). This file instructs GitHub to only run
the action on pushes and pull requests that invlude the /api directory.
It will install the dependencies and then run the tests provided.

Updating the npm script was necessary because there is a bug in Mocha
that causes it to not exit after the tests are complete.
See this for more info:
https://stackoverflow.com/questions/50372866/mocha-not-exiting-after-test