### PR TITLE
Fix Bug With Deploy Job in Workflow File

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,16 +24,18 @@ jobs:
   client-tests:
     runs-on: ubuntu-latest
     steps:
-      - run: echo client tests!
+      - run: |
+                echo ${{github.ref}}
+                echo ${{github.event_name}}
   integration-tests:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.ref == 'refs/heads/master' && github.event_name == 'push')
     needs: [api-tests, client-tests]
     steps:
       - run: echo integration tests!
   deploy:
     runs-on: ubuntu-latest
     needs: [api-tests, client-tests, integration-tests]
-    if: github.ref == 'refs/head/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
       - run: echo deploying code!!


### PR DESCRIPTION
The deploy job had a dependency on the integration job, but the
integration job was only setup to run on pull request events. This means
that it would never run on pushses to master branch, and this caused the
deploy job to never run. To fix that I updated the integration job to
check for pull requests or pushes to master branch.

There was also a typo when checking the ref on the deploy job.