### PR TITLE
Fix Security Vulnerability with websocket-extensions

### DIFF
--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8546,8 +8546,8 @@ websocket-driver@>=0.5.1:
     safe-buffer ">=5.1.0"
     websocket-extensions ">=0.1.1"
 
-websocket-extensions@>=0.1.1:
-  version "0.1.3"
+websocket-extensions@^0.1.4:
+  version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:


### PR DESCRIPTION
Dependabot found a security vulnerability with websocket-extensions
that requires it to be at least v0.1.4.