### PR TITLE
Create AWS EC2 Instance Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 # AWS keys
 **/.env
 
+# Terraform
+*.tfstate*
+**/.terraform
+
 # misc
 .DS_Store
 .env.local

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Recipe App
+This is a fullstack application to keep track of my favorite recipes.
+
+The app uses a React front end with a NodeJS API. It's served by a multi-container Docker setup that's hosted on AWS. For CI/CD I use GitHub Actions to automate the testing and deployment.
+
+## What I Learned
+- Bulding an API with NodeJS
+- Developing a front end with React and interacting with an API
+- Creating a multi-container Docker setup with docker-compose
+- Implementing CI/CD with GitHub Actions
+- Various AWS services (EC2, S3, DynamoDB, CloudFront)

--- a/terraform/cloud-init.yml
+++ b/terraform/cloud-init.yml
@@ -1,0 +1,8 @@
+#cloud-config
+runcmd:
+  - [sudo, yum, update, -y]
+  - [sudo, amazon-linux-extras, install, docker, -y]
+  - [sudo, service, docker, start]
+  - [sudo, usermod, -a, -G, docker, ec2-user]
+  - 'sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose'
+  - [sudo, chmod, +x, /usr/local/bin/docker-compose]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,47 @@
+provider "aws" {
+  region     = "us-east-2"
+  access_key = ""
+  secret_key = ""
+}
+
+resource "aws_security_group" "recipe-app-sg" {
+  name        = "recipe-app-sg"
+  description = "TODO"
+
+  ingress {
+    description = "Allow SSH connections"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    # TODO update this block to only allow my IPs
+  }
+
+  ingress {
+    description = "Allow HTTP connections"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "recipe-app-vm" {
+  ami             = "ami-026dea5602e368e96"
+  instance_type   = "t2.micro"
+  key_name        = "test-key-ec2"
+  security_groups = ["${aws_security_group.recipe-app-sg.name}"]
+  user_data = file("./cloud-init.yml") # install docker using cloud-init
+}
+
+resource "aws_eip" "ip" {
+  instance = aws_instance.recipe-app-vm.id
+}


### PR DESCRIPTION
In order to create an EC2 instance, a security group with inbound
and outbound rules must be created. Cloud-Init is used to run the
commands necessary to install Docker on a Linux AMI.

Additionally, I created an Elastic IP so that each time the instance
is destroyed and re-created it will have the same IP (assuming that
the EIP resource doesn't get destroyed).