### PR TITLE
Read AWS Secrets from .tfvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 # Terraform
 *.tfstate*
 **/.terraform
+**/terraform.tfvars
 
 # misc
 .DS_Store

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,10 @@
+variable aws_access_key {}
+variable aws_secret_key {}
+
 provider "aws" {
   region     = "us-east-2"
-  access_key = ""
-  secret_key = ""
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
 }
 
 resource "aws_security_group" "recipe-app-sg" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,2 @@
+aws_access_key = "your-access-key"
+aws_secret_key = "your-secret-key"


### PR DESCRIPTION
Including AWS keys in version control is a horrible idea for many
reasons. Using the functionality of Terraform's .tfvars file allows me
to put the secrets in that file and hide it from version control. This
way when Terraform runs locally, it will run as expected, all while hiding the
secrets from Git.

Additionally, a .tfvars.example file is included to show the format of
the .tfvars file without actually exposing the real secrets.