### PR TITLE
Add Margin to Filter Buttons

### DIFF
--- a/client/src/components/ActiveTag.js
+++ b/client/src/components/ActiveTag.js
@@ -12,7 +12,7 @@ class ActiveTag extends React.Component {
   }
 
   render() {
-    return <Chip label={this.props.tag} color="primary" onClick={this.handleDelete} onDelete={this.handleDelete}/>
+    return <Chip style={{margin: '3px'}} label={this.props.tag} color="primary" onClick={this.handleDelete} onDelete={this.handleDelete}/>
   }
 }
 

--- a/client/src/components/RecipeFilter.js
+++ b/client/src/components/RecipeFilter.js
@@ -7,7 +7,7 @@ class RecipeFilter extends React.Component {
   }
 
   render() {
-    return <Chip label={this.props.tag} color="default" onClick={this.handleClick}/>
+    return <Chip style={{margin: '3px'}} label={this.props.tag} color="default" onClick={this.handleClick}/>
   }
 }
 


### PR DESCRIPTION
The filtering buttons were looking relatively crammed and needed to be spaced out. To acheive this, adding a small margin to each Chip component fixed the problem.