### PR TITLE
Fix Docker Bugs and Bump Node Image Version

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:14.15-alpine
 
 WORKDIR /api
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:8
+FROM node:14.15-alpine
 
 WORKDIR /client
 
-#COPY package*.json ./
-#RUN npm install --silent
+COPY package*.json ./
+RUN npm install --silent
 
-#COPY . .
+COPY . .
 
 EXPOSE 3000
 EXPOSE 35729

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - '5000:5000'
     volumes:
-      - //c/Users/Chris/projects/recipe-app/api:/api
+      - ./api:/api
     environment:
       - NODE_ENV=dev
   client:
@@ -16,4 +16,4 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING=true
     volumes:
-      - //c/Users/Chris/projects/recipe-app/client:/client
+      - ./client:/client


### PR DESCRIPTION
For both the client and API Dockerfiles, the node image version was bumped
from 8 to 14.15-alpine. I have no idea why I was using such an old Node version,
but it's been fixed.

The client's Dockerfile had some lines commented out (I'm not sure
how this didn't blow everything up???) and the docker-compose override
file was updated to use relative paths for the volumes.