### PR TITLE
Add /api/v1 to /login Route

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -131,7 +131,7 @@ app.post('/api/v1/recipes', jwtMiddleware, verifyRecipeDoesNotExist, (req, res) 
   })
 });
 
-app.post("/login", (req, res) => {
+app.post("/api/v1/login", (req, res) => {
   username = req.body.username
   password = req.body.password
 

--- a/api/test/recipes.js
+++ b/api/test/recipes.js
@@ -68,10 +68,10 @@ describe('GET /api/v1/bad-endpoint',  () => {
   });
 });
 
-describe('POST /login', () => {
+describe('POST /api/v1/login', () => {
   it('Should return 401 error', (done) => {
     chai.request(app)
-      .post('/login')
+      .post('/api/v1/login')
       .send({ username: "abc", password: "123" })
       .end((err, res) => {
         expect(res.status).to.equal(401);


### PR DESCRIPTION
Due to how nginx routes requests to the API, it thought that the /login
route was part of the static HTML. Therefore, the route needed to be
updated so nginx routes it to the Express server.