### PR TITLE
Update Nginx Conf to Serve Login Page

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -10,6 +10,7 @@ http {
   server {
     location / {
       root /build;
+      try_files $uri /index.html;
     }
 
     location /api/ {


### PR DESCRIPTION
In production the login page was not viewable. This was because
Nginx was not setup to serve anything that wasn't in the build folder,
so a try_files directive had to be added.

See here for more details:
https://stackoverflow.com/questions/43951720/react-router-and-nginx